### PR TITLE
refactor: Update deprecated assert methods

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -7,29 +7,31 @@ describe('NGBank', function() {
   let banks = [];
 
   before(function(done) {
-    banks = JSON.parse(fs.readFileSync(process.cwd() + '/db/banks.json', 'utf8'));
+    banks = JSON.parse(
+      fs.readFileSync(process.cwd() + '/db/banks.json', 'utf8')
+    );
     done();
   });
 
   it('should getbanks', function(done) {
-    assert.deepEqual(ngBanks.getBanks(), banks);
+    assert.deepStrictEqual(ngBanks.getBanks(), banks);
     done();
   });
 
   it('should getbanks with callback', function(done) {
     ngBanks.getBanks(function(err, data) {
-      assert.deepEqual(data, banks);
+      assert.deepStrictEqual(data, banks);
       done();
     });
   });
 
   it('should getbank', function(done) {
-    assert.deepEqual(ngBanks.getBank('EPB'), {
-      "name": "ENTERPRISE BANK",
-      "code": "084",
-      "slug": "EPB",
-      "ussd": {
-        "code": null
+    assert.deepStrictEqual(ngBanks.getBank('EPB'), {
+      name: 'ENTERPRISE BANK',
+      code: '084',
+      slug: 'EPB',
+      ussd: {
+        code: null
       }
     });
     done();
@@ -37,12 +39,12 @@ describe('NGBank', function() {
 
   it('should getbank with callback', function(done) {
     ngBanks.getBank('EPB', function(err, data) {
-      assert.deepEqual(data, {
-        "name": "ENTERPRISE BANK",
-        "code": "084",
-        "slug": "EPB",
-        "ussd": {
-          "code": null
+      assert.deepStrictEqual(data, {
+        name: 'ENTERPRISE BANK',
+        code: '084',
+        slug: 'EPB',
+        ussd: {
+          code: null
         }
       });
     });
@@ -51,12 +53,12 @@ describe('NGBank', function() {
 
   it('should have getbank in memory [EPB]', function(done) {
     ngBanks.getBank('EPB');
-    assert.deepEqual(ngBanks.store['EPB'], {
-      "name": "ENTERPRISE BANK",
-      "code": "084",
-      "slug": "EPB",
-      "ussd": {
-        "code": null
+    assert.deepStrictEqual(ngBanks.store['EPB'], {
+      name: 'ENTERPRISE BANK',
+      code: '084',
+      slug: 'EPB',
+      ussd: {
+        code: null
       }
     });
     done();
@@ -64,33 +66,33 @@ describe('NGBank', function() {
 
   it('should have getbank in memory [063]', function(done) {
     ngBanks.getBank('063');
-    assert.deepEqual(ngBanks.store['063'], {
-      "name": "DIAMOND BANK PLC",
-      "code": "063",
-      "slug": "DMB",
-      "ussd": {
-        "code": "*710#"
+    assert.deepStrictEqual(ngBanks.store['063'], {
+      name: 'DIAMOND BANK PLC',
+      code: '063',
+      slug: 'DMB',
+      ussd: {
+        code: '*710#'
       }
     });
     done();
   });
 
   it('should have both [EPB] and [063] in memory', function(done) {
-    assert.deepEqual(ngBanks.store, {
-      "EPB": {
-        "name": "ENTERPRISE BANK",
-        "code": "084",
-        "slug": "EPB",
-        "ussd": {
-          "code": null
+    assert.deepStrictEqual(ngBanks.store, {
+      EPB: {
+        name: 'ENTERPRISE BANK',
+        code: '084',
+        slug: 'EPB',
+        ussd: {
+          code: null
         }
       },
-      "063": {
-        "name": "DIAMOND BANK PLC",
-        "code": "063",
-        "slug": "DMB",
-        "ussd": {
-          "code": "*710#"
+      '063': {
+        name: 'DIAMOND BANK PLC',
+        code: '063',
+        slug: 'DMB',
+        ussd: {
+          code: '*710#'
         }
       }
     });
@@ -98,8 +100,8 @@ describe('NGBank', function() {
   });
 
   it('should have empty memory', function(done) {
-    assert.equal(ngBanks.reset(), true)
-    assert.deepEqual(ngBanks.store, {});
+    assert.strictEqual(ngBanks.reset(), true);
+    assert.deepStrictEqual(ngBanks.store, {});
     done();
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -106,4 +106,17 @@ describe('NGBank', function() {
   });
 
   // TODO: add test to mock and handle JSON parsing error
+  it('should parse the banks JSON correctly', function(done) {
+    fs.readFile(process.cwd() + '/db/banks.json', 'utf8', (err, data) => {
+      const hasError = err ? true : false;
+      const parsedData = JSON.parse(data);
+      assert.deepStrictEqual(parsedData, banks);
+      assert.strictEqual(
+        hasError,
+        false,
+        'Error encountered while prsing JSON'
+      );
+    });
+    done();
+  });
 });


### PR DESCRIPTION
1. Update deprecated assert methods
The `assert.equal` and the `assert.deepEqual` methods have become deprecated.
I updated both to the new `assert.deepEqual` and `assert.deepStrictEqual` methods
All tests still pass
[Docs here](https://nodejs.org/api/assert.html#assert_assert_deepequal_actual_expected_message)

2. Add test to mock and handle JSON parsing error
